### PR TITLE
Bugfix save to ds

### DIFF
--- a/pyatoa/utils/read.py
+++ b/pyatoa/utils/read.py
@@ -90,7 +90,8 @@ def read_sem(path, origintime=None, location='', precision=4):
         data = np.array(data)
 
     if origintime is None:
-        print("No origintime given, setting to default 1970-01-01T00:00:00")
+        logger.warning("No origintime given, setting to default "
+                       "1970-01-01T00:00:00")
         origintime = UTCDateTime("1970-01-01T00:00:00")
 
     # We assume that dt is constant after 'precision' decimal points


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?
Small bug fix where setting Pyatoa's config option `save_to_ds` as False would not allow the Manager to write to the dataset with its `write` function which is not intended behavior. `save_to_ds` was meant to prevent automatic saving which occurs during each of the individual processing steps

### Why was it initiated?  Any relevant Issues?
This was causing some tests to fail in SeisFlows as misfit windows could not be saved during Pyaflowa preprocessing

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [X] Any new features or fixed regressions covered by new tests.
- [X] Any new or changed features have been fully documented.
- [X] Significant changes have been added to `CHANGELOG.md`.
- [X] First time contributors have added your name to CONTRIBUTORS.txt .


