### PR TITLE
bugfixing time offset and waveform misfit naming

### DIFF
--- a/pyatoa/core/config.py
+++ b/pyatoa/core/config.py
@@ -760,7 +760,7 @@ def format_adj_src_type(choice):
     elif choice in ["mt", "mtm", "multitaper_misfit", "multitaper"]:
         adj_src_type = "multitaper_misfit"
     elif choice in ["wav", "wave", "waveform", "w"]:
-        adj_src_type = "waveform"
+        adj_src_type = "waveform_misfit"
     else:
         raise ValueError(f"'{choice}' does not match available adjoint source "
                          f"types, must be 'cc', 'mt', or 'wav'")

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -661,13 +661,17 @@ class Manager:
             )
 
         # Determine if synthetics start before the origintime
-        if self.event is not None:
+        if hasattr(self.st_syn[0].stats, "time_offset"):
+            self.stats.time_offset_sec = self.st_syn[0].stats.time_offset
+        elif self.event is not None:
             self.stats.time_offset_sec = (self.st_syn[0].stats.starttime -
                                           self.event.preferred_origin().time
                                           )
-            logger.debug(f"time offset is {self.stats.time_offset_sec}s")
         else:
+            logger.warning("cannot find information relating to synthetic time "
+                           "offset. Setting to 0")
             self.stats.time_offset_sec = 0
+        logger.info(f"synthetic time offset is {self.stats.time_offset_sec}s")
 
         self.stats.standardized = True
 


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?
Bug fixes 'time_offset' not being properly set, and 'waveform misfit' not being properly named

### Why was it initiated?  Any relevant Issues?
Initiated due to relevant issues: https://github.com/adjtomo/pyatoa/issues/13 and https://github.com/adjtomo/pyatoa/issues/14

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [X] Any new features or fixed regressions covered by new tests.
- [X] Any new or changed features have been fully documented.
- [ ] Significant changes have been added to `CHANGELOG.md`.
- [ ] First time contributors have added your name to CONTRIBUTORS.txt .


