### PR TITLE
Fixing timing issues

### DIFF
--- a/pyatoa/core/config.py
+++ b/pyatoa/core/config.py
@@ -30,7 +30,7 @@ class Config:
                  event_id=None, min_period=10, max_period=30, filter_corners=2,
                  client=None, rotate_to_rtz=False, unit_output="DISP",
                  pyflex_preset="default", component_list=None,
-                 adj_src_type="cc_traveltime_misfit", start_pad=20, end_pad=500,
+                 adj_src_type="cc_traveltime_misfit", start_pad=0, end_pad=500,
                  observed_tag="observed", synthetic_tag=None,
                  synthetics_only=False, win_amp_ratio=0., paths=None,
                  save_to_ds=True, **kwargs):
@@ -75,9 +75,13 @@ class Config:
         :param adj_src_type: method of misfit quantification for Pyadjoint
         :type start_pad: int
         :param start_pad: seconds before event origintime to grab waveform data
-            for use by data gathering class
+            for use by data gathering class. Also zero pads data and synthetics
+            before origin time. Only used for processing, padded zeros will NOT
+            be saved alongside data
         :type end_pad: int
         :param end_pad: seconds after event origintime to grab waveform data
+            Also used to zero pad after event origin time. Only for processing,
+            padded zeros will NOT be saved alongside data
         :type synthetics_only: bool
         :param synthetics_only: If the user is doing a synthetic-synthetic
             example, e.g. in a checkerboard test, this will tell the internal

--- a/pyatoa/plugins/pyflex_presets.py
+++ b/pyatoa/plugins/pyflex_presets.py
@@ -35,6 +35,10 @@ pyflex_presets = {
     # Empty preset or 'default' will use default init values
     "default": {
     },
+    # 'Custom' preset tells Pyatoa that the User will be providing their own
+    # windowing parameters to the Pyatoa config object
+    "custom": {
+    },
     # Example configuration from the Pyflex website
     "example": {
         "stalta_waterlevel": 0.08,

--- a/pyatoa/visuals/wave_maker.py
+++ b/pyatoa/visuals/wave_maker.py
@@ -11,6 +11,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 from pyatoa.utils.calculate import normalize_a_to_b, abs_max
+from pyatoa import logger
 
 
 # Hardcoded colors that represent rejected misfit windows. Description from 

--- a/pyatoa/visuals/wave_maker.py
+++ b/pyatoa/visuals/wave_maker.py
@@ -202,14 +202,25 @@ class WaveMaker:
                       linewidth=linewidth, zorder=9, label=f"STA/LTA")
 
         if plot_waterlevel:
-            # Plot the waterlevel of the STA/LTA defined by Pyflex Config
-            ax.axhline(y=waterlevel, xmin=self.time_axis[0], 
-                       xmax=self.time_axis[-1], alpha=0.4, zorder=8, 
-                       linewidth=linewidth, c=stalta_color, linestyle='--')
-            ax.annotate(f"stalta_waterlevel = {stalta_wl}", alpha=0.7, 
-                        fontsize=fontsize,
-                        xy=(0.75 * (xmax - xmin) + xmin, waterlevel)
-                        )
+            # Plot static STALTA waterlevel 
+            if isinstance(waterlevel, float):
+                ax.axhline(y=waterlevel, xmin=self.time_axis[0], 
+                           xmax=self.time_axis[-1], alpha=0.4, zorder=8, 
+                           linewidth=linewidth, c=stalta_color, linestyle='--')
+
+                ax.annotate(f"stalta_waterlevel = {stalta_wl}", alpha=0.7, 
+                            fontsize=fontsize,
+                            xy=(0.75 * (xmax - xmin) + xmin, waterlevel)
+                            )
+            # Plot array-like STALTA waterlevel
+            else:
+                ax.plot(self.time_axis, waterlevel, alpha=0.4, zorder=8, 
+                        linewidth=linewidth, c=stalta_color, linestyle='--')
+
+                ax.annotate(f"stalta_waterlevel", alpha=0.7, 
+                            fontsize=fontsize, 
+                            xy=(0.75 * (xmax - xmin) + xmin, .1)
+                            )
 
         return [b2]
 


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?
Fixes time keeping issues throughout Pyatoa related to SPECFEM parameter `USER_T0` as well as time offsets related to zero padding.  It also allows for array-like STA/LTA to be plotted on waveform figures.

SPECFEMS `USER_T0` defines the start of waveforms but not the t=0 point (origin time). This information is now explicitly calculated and the name of the internal parameter has been changed to match.

### Why was it initiated?  Any relevant Issues?

Waveform figures with zero-padding were not showing the correct t=0 time.

Time offsets were being incorrectly set during the setup of a Pyatoa Manager class. Although this does not propagate downstream to the adjoint sources which are ultimately the bread and butter of the inversion, it has an effect on the waveform figures and where they decide t=0 is w.r.t waveforms.

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions covered by new tests.
- [ ] Any new or changed features have been fully documented.
- [ ] Significant changes have been added to `CHANGELOG.md`.
- [ ] First time contributors have added your name to CONTRIBUTORS.txt .


