### PR TITLE
Bugfix numerical noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,4 @@
 
 - Bugfix: Gatherer attempting to access a removed Config parameter
 - Resolve PyPDF2 -> PyPDF dependency deprecation warning
+- Bugfix: Manager.standardize() only resamples if required, otherwise small time shifting is introduced (Issue \#34)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 Chow, Bryant
+Örsvuran, Ridvan

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -725,11 +725,13 @@ class Manager:
         if dt_st > 0:
             self.st_obs = zero_pad(self.st_obs, dt_st, before=True, after=False)
 
-        # Match sampling rates
-        if standardize_to == "syn":
-            self.st_obs.resample(self.st_syn[0].stats.sampling_rate)
-        else:
-            self.st_syn.resample(self.st_obs[0].stats.sampling_rate)
+        # Match sampling rates only if they differ
+        if self.st_syn[0].stats.sampling_rate != \
+                self.st_obs[0].stats.sampling_rate: 
+            if standardize_to == "syn":
+                self.st_obs.resample(self.st_syn[0].stats.sampling_rate)
+            else:
+                self.st_syn.resample(self.st_obs[0].stats.sampling_rate)
 
         # Match start and endtimes
         self.st_obs, self.st_syn = trim_streams(

--- a/pyatoa/tests/test_manager.py
+++ b/pyatoa/tests/test_manager.py
@@ -328,7 +328,7 @@ def test_resample_numerical_noise(mgmt_pre):
 
     # Take some parameters from the Issue
     mgmt_pre.config.adj_src_type = "waveform"
-    mgmt_pre.config.min_period = 0.05
+    mgmt_pre.config.min_period = 20
     mgmt_pre.config.max_period = 100.
     mgmt_pre.config.st_obs_type = "syn"
     mgmt_pre.config._set_external_configs()
@@ -340,7 +340,7 @@ def test_resample_numerical_noise(mgmt_pre):
     # mgmt_pre.plot(choice="wav")  # creates the figure shown in Issue #34 
 
     # adjoint sources should be zero because these are the same trace
-    for comp, adjsrc in mgmt_pre.adjsrcs:
+    for comp, adjsrc in mgmt_pre.adjsrcs.items():
         assert(adjsrc.adjoint_source.max() == 0)
         assert(adjsrc.adjoint_source.min() == 0)
 


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?

Small fix and test to keep an eye on unwanted time shifting caused by resampling data that does not require resampling.
See Issue #34 for description and discussion.

### Why was it initiated?  Any relevant Issues?

Bug that is can be encountered in the wild. Relevant Issue #34

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions covered by new tests.
- [ ] Any new or changed features have been fully documented.
- [x] Significant changes have been added to `CHANGELOG.md`.
- [x] First time contributors have added your name to CONTRIBUTORS.txt .


