### PR TITLE
Remove abstraction from windowing procedure

### DIFF
--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -949,7 +949,7 @@ class Manager:
                 continue
 
         # If no windows provided, gather windows using waveform data
-        if windows is not None:
+        if not windows:
             self._select_windows_plus()
 
         logger.info(f"{self.stats.nwin} window(s) total found")

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -862,8 +862,7 @@ class Manager:
                         key == "syn" and self.config.st_syn_type == "obs"):
                     st.remove_response(inventory=self.inv, plot=False, **kwargs)
 
-            # Detrend and taper pre-filter
-            st.detrend("simple")
+            # Set mean to 0 and taper ends to prep for filtering
             st.detrend("demean")
             st.taper(taper_percentage)
 

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -990,11 +990,12 @@ class Manager:
             return_previous = False
 
         logger.info(f"retrieving windows from dataset "
-                    f"i{iteration:0>2} s{step_count:0>2}")
+                    f"i{iteration:0>2}s{step_count:0>2}")
 
         net, sta, _, _ = self.st_obs[0].get_id().split(".")
         # Function will return empty dictionary if no acceptable windows found
-        windows = load_windows(ds=ds, net=net, sta=sta,
+        windows = load_windows(ds=ds, net=net, sta=sta, 
+                               components=self.config.component_list,
                                iteration=iteration, step_count=step_count,
                                return_previous=return_previous
                                )

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -551,8 +551,7 @@ class Manager:
 
         self.standardize(standardize_to=standardize_to)
         self.preprocess(**kwargs)
-        self.window(fix_windows=fix_windows, iteration=iteration,
-                    step_count=step_count)
+        self.window()
         self.measure()
 
     def flow_multiband(self, periods, standardize_to="syn", fix_windows=False,

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -1048,6 +1048,7 @@ class Manager:
         will be used internally for plotting.
 
         .. note::
+
             Pyflex will throw a ValueError if the arrival of the P-wave
             is too close to the initial portion of the waveform, considered the
             'noise' section. This happens for short source-receiver distances

--- a/pyatoa/tests/test_asdf_utils.py
+++ b/pyatoa/tests/test_asdf_utils.py
@@ -110,7 +110,7 @@ def test_add_misfit_windows(empty_dataset, mgmt_post):
                            path=path)
 
     windows = empty_dataset.auxiliary_data.MisfitWindows[path]
-    assert(len(windows.list()) == 2)
+    assert(len(windows.list()) == 3)
 
     for comp, window_list in mgmt_post.windows.items():
         assert(len(window_list) == 1)
@@ -146,7 +146,7 @@ def test_add_adjoint_sources(empty_dataset, mgmt_post):
                             )
 
     adjsrcs = empty_dataset.auxiliary_data.AdjointSources[path]
-    assert(len(adjsrcs.list()) == 2)
+    assert(len(adjsrcs.list()) == 3)
 
     # Just check misfit value is correct
     for comp, adjsrc in mgmt_post.adjsrcs.items():

--- a/pyatoa/tests/test_manager.py
+++ b/pyatoa/tests/test_manager.py
@@ -66,16 +66,16 @@ def config():
     return Config(event_id="2018p130600")
 
 
-# @pytest.fixture
-# def window():
-#     """
-#     Pre-gathered window for this specific source-receiver configuration
-#     This doesn't actually match the data... strange. Not used.
-#     """
-#     return json.load(open(
-#         "./test_data/test_window_NZ_BFZ_N_0_2018p130600.json"))["windows"][0]
-#
-#
+@pytest.fixture
+def windows():
+    """
+    Pre-gathered window for this specific source-receiver configuration
+    This doesn't actually match the data... strange. Not used.
+    """
+    return json.load(open(
+        "./test_data/test_window_NZ_BFZ_N_0_2018p130600.json"))
+
+
 # @pytest.fixture
 # def adjoint_source():
 #     """
@@ -206,6 +206,11 @@ def test_select_window(mgmt_pre):
     # Ensure the correct number of windows are chosen
     for comp, nwin in {"N": 1, "E": 1}.items():
         assert(len(mgmt_pre.windows[comp]) == nwin)
+
+def test_provide_windows(mgmt_pre, windows):
+    """
+    Test User-provided windows given to the window function
+    """
 
 
 def test_save_and_retrieve_windows(tmpdir, mgmt_post):

--- a/pyatoa/utils/asdf/load.py
+++ b/pyatoa/utils/asdf/load.py
@@ -55,19 +55,19 @@ def load_windows(ds, net, sta, iteration, step_count, return_previous=False,
     window_dict = {}    
     if return_previous:
         # Retrieve windows from previous iter/step
-        windows = previous_windows(windows=windows, iteration=iteration,
-                                   step_count=step_count)
+        window_attr = previous_windows(windows=windows, iteration=iteration,
+                                       step_count=step_count)
     else:
         if hasattr(windows, iteration) and \
                             hasattr(windows[iteration], step_count):
-             Attempt to retrieve windows from the given iter/step
+            # Attempt to retrieve windows from the given iter/step
             logger.debug(f"searching for windows in {iteration}{step_count}")
-            windows = windows[iteration][step_count]
+            window_attr = windows[iteration][step_count]
 
     # Convert the Windows axiliary data into PyFlex Windows objects
-    window_dict = dataset_windows_to_pyflex_windows(windows=prev_windows,
+    window_dict = dataset_windows_to_pyflex_windows(windows=window_attr,
                                                     network=net, station=sta,
-                                                    compenents=components)
+                                                    components=components)
 
     return window_dict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyatoa"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python's Adjoint Tomography Operations Assistant"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?

Motivation:
- Removes abstraction from the Manager window function.
- Previously, User's provided an argument to window(fix_windows: bool) to determine whether windows were selected, or re-used (from an ASDFDataSet). This was a bit too abstract
- To be more explicit, the window() function *only* selects windows. A new function `retrieve_windows_from_dataset` is used in lieu of the window function in order to retrieve windows from a previous evaluation

Changelog: 
- Function `Manager.window()` is now only used for selecting new windows
- Function `Manager.retrieve_windows_from_dataset()` is now used for selecting previously evaluated windows from an ASDFDataSet
- Feature: Can now retrieve window by component, previously all windows in Dataset were returned
- Adjusted `Manager.flow` function to deal with new setup
- Misc Bugfix: Remove 'simple' detrend from preprocessing steps because it was causing processing artefacts on non-tapered data
- Misc: function `format_event_name` can now handle all events output by PySEP's `read_events_plus`


### Why was it initiated?  Any relevant Issues?

- Setting up for Pyatoa to be able to used manually selected windows by Users. This will come in a future PR
- And to remove some obscurity from the processing workflow

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions covered by new tests.
- [ ] Any new or changed features have been fully documented.
- [ ] Significant changes have been added to `CHANGELOG.md`.
- [ ] First time contributors have added your name to CONTRIBUTORS.txt .


