### PR TITLE
Bugfix Trim streams failing silently

### DIFF
--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -765,13 +765,13 @@ class Manager:
             else:
                 self.st_syn.resample(self.st_obs[0].stats.sampling_rate)
 
-        # Match start and endtimes
+        # Match start/endtimes by trimming the 'obs' waveforms to match 'syn'
         self.st_obs, self.st_syn = trim_streams(
             st_a=self.st_obs, st_b=self.st_syn,
             force={"obs": "a", "syn": "b"}[standardize_to]
             )
 
-        # Match the number of samples 
+        # If 'obs' is not long enough, pad end of 'obs' with 0s
         self.st_obs, self.st_syn = match_npts(
             st_a=self.st_obs, st_b=self.st_syn,
             force={"obs": "a", "syn": "b"}[standardize_to]

--- a/pyatoa/tests/test_process_util.py
+++ b/pyatoa/tests/test_process_util.py
@@ -115,7 +115,32 @@ def test_zero_pad(st_obs):
         assert(st[0].stats.npts - npts == npts_check)
 
 
-def test_trim_streams_and_match_npts(st_obs, st_syn):
+def test_trim_streams(st_obs, st_syn):
+    """
+    Test Stream trimming functionality
+    """
+    st_a = st_obs.copy()
+    st_b = st_syn.copy()
+
+    # Resample first so that we can actually trim the exact same start and 
+    # end times
+    st_a.resample(st_b[0].stats.sampling_rate)
+
+    # Trim A so we know it is different from B
+    st_a.trim(starttime=st_b[0].stats.starttime + 100,
+              endtime=st_b[0].stats.endtime - 100)
+
+    assert(st_a[0].stats.starttime != st_b[0].stats.starttime)
+    assert(st_a[0].stats.endtime != st_b[0].stats.endtime)
+
+    # Trim streams to the same time window
+    st_at, st_bt = process.trim_streams(st_a=st_a, st_b=st_b, force="a")
+
+    assert(st_at[0].stats.starttime == st_bt[0].stats.starttime)
+    assert(st_at[0].stats.endtime == st_bt[0].stats.endtime)
+
+
+def test_match_npts(st_obs, st_syn):
     """
     Ensure that forcing number of points standardization works
     """
@@ -125,10 +150,6 @@ def test_trim_streams_and_match_npts(st_obs, st_syn):
     # Downsample observations to synthetics
     st_a.resample(st_b[0].stats.sampling_rate)
     assert(st_a[0].stats.npts != st_b[0].stats.npts)
-
-    # Trim obs data down to match syn data
-    st_a, st_b = process.trim_streams(st_a=st_a, st_b=st_b, force="b")
-    assert(st_a[0].stats.npts == st_b[0].stats.npts)
 
     # Purposefully mismatch npts and then pad with 0s
     st_a[0].trim(endtime=st_a[0].stats.endtime - 1)

--- a/pyatoa/utils/process.py
+++ b/pyatoa/utils/process.py
@@ -145,32 +145,23 @@ def zero_pad(st, pad_length_in_seconds, before=True, after=True):
     return st_pad
 
 
-def trim_streams(st_a, st_b, precision=1E-3, force=None):
+def trim_streams(st_a, st_b, force=None):
     """
-    Trim two streams to common start and end times,
-    Do some basic preprocessing before trimming.
-    Allows user to force one stream to conform to another.
-    Assumes all traces in a stream have the same time.
-    Prechecks make sure that the streams are actually different
-
+    Trim two streams to common start and end times, allowing user to `force` 
+    one stream to conform to another. Assumes all traces in a stream have the 
+    same time.
+    
     :type st_a: obspy.stream.Stream
     :param st_a: streams to be trimmed
     :type st_b: obspy.stream.Stream
     :param st_b: streams to be trimmed
-    :type precision: float
-    :param precision: precision to check UTCDateTime differences
     :type force: str
     :param force: "a" or "b"; force trim to the length of "st_a" or to "st_b",
         if not given, trims to the common time
     :rtype: tuple of obspy.stream.Stream
     :return: trimmed stream objects in the same order as input
+    :raises AssertionError: if the streams cannot be trimmed successfully
     """
-    # Check if the times are already the same
-    if st_a[0].stats.starttime - st_b[0].stats.starttime < precision and \
-            st_a[0].stats.endtime - st_b[0].stats.endtime < precision:
-        logger.debug(f"start and endtimes already match to {precision}")
-        return st_a, st_b
-
     # Force the trim to the start and end times of one of the streams
     if force:
         if force.lower() == "a":
@@ -209,6 +200,11 @@ def trim_streams(st_a, st_b, precision=1E-3, force=None):
                 tr.stats.starttime = start_set
             elif dt >= tr.stats.delta:
                 logger.warning(f"{tr.id} starttime is {dt}s greater than delta")
+
+    assert(st_a_out[0].stats.starttime == st_b_out[0].stats.starttime), \
+        "unable to trim streams and match starttimes"
+    assert(st_a_out[0].stats.endtime == st_b_out[0].stats.endtime), \
+        "unable to trim streams and match endtimes"
 
     return st_a_out, st_b_out
 


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?
- Removes a broken check in processing function `trim_streams` that would silently pass untrimmed streams due to an incorrect check evaluation
- Updates processing function `match_npts` to allow it to deal with less or more npts. Prior implementation was too rigid
- Updates tests for `trim_streams` and `match_npts` to better cover function use cases
- Added assertion checks during stream trims and matching npts to make sure that these failures cannot happen

### Why was it initiated?  Any relevant Issues?
User noticed that during a SeisFlows inversion, their waveforms were showing a significant time shift that suggested streams were not being trimmed to the same start and end time, leading me to find this bug which was causing trimming to fail silently.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions covered by new tests.
- [ ] Any new or changed features have been fully documented.
- [ ] Significant changes have been added to `CHANGELOG.md`.
- [ ] First time contributors have added your name to CONTRIBUTORS.txt .


