### PR TITLE
Improve Inspector Report Functionality

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'Pyatoa'
-copyright = '2023, adjTomo'
+copyright = '2024, adjTomo'
 author = 'adjTomo Dev Team'
 
 # The short X.Y version

--- a/pyatoa/core/inspector.py
+++ b/pyatoa/core/inspector.py
@@ -1192,8 +1192,8 @@ class Inspector(InspectorPlotter):
 
         return minmax_dict
 
-    def compare_events(self, iteration_a=None, step_count_a=None, iteration_b=None,
-                step_count_b=None):
+    def compare_events(self, iteration_a=None, step_count_a=None, 
+                       iteration_b=None, step_count_b=None):
         """
         Compare the misfit and number of windows on an event by event basis
         between two evaluations. Provides absolute values as well as
@@ -1315,16 +1315,34 @@ class Inspector(InspectorPlotter):
 
         return df
     
-    def compare_misfits(self):
+    def compare_misfits(self, iteration_a=None, step_count_a=None,
+                        iteration_b=None, step_count_b=None):
         """
         Compare the misfit values between the final and initial model for each
-        source receiver pair
+        source receiver pair. Returns differences of unscaled misfit and 
+        difference in number of windows between two evaluations. 
+
+        .. note::
+
+            See also compare_events() for a similar function but for events only
+
+        :type iteration_a: str
+        :param iteration_a: initial iteration to use in comparison
+        :type step_count_a: str
+        :param step_count_a: initial step count to use in comparison
+        :type iteration_b: str
+        :param iteration_b: final iteration to use in comparison
+        :type step_count_b: str
+        :param step_count_b: final step count to use in comparison
+        :rtype: pandas.core.data_frame.DataFrame
+        :return: a data frame containing differences of misfit and number of
+            windows between final and initial models
         """
         iter_start, step_start = self.validate_evaluation(
-            iteration=None, step_count=None, choice="initial"
+            iteration=iteration_a, step_count=step_count_a, choice="initial"
             )
         iter_end, step_end = self.validate_evaluation(
-            iteration=None, step_count=None, choice="final"
+            iteration=iteration_b, step_count=step_count_b, choice="final"
             )
         
         _windows = self.windows  
@@ -1354,11 +1372,11 @@ class Inspector(InspectorPlotter):
                  f"nwin_{sfx_end}", f"nwin_{sfx_start}"], 
                 axis=1, inplace=True)
 
-        df.sort_values(by="diff_misfit")
-
+        # Reset windows so User can still use the Inspector as advertised
         self.windows = _windows
 
-        return df
+        # Isolate the largest misfit offenders
+        return df.sort_values(by="diff_misfit")
     
     def filter_sources(self, lat_min=None, lat_max=None, lon_min=None,
                        lon_max=None, depth_min=None, depth_max=None,

--- a/pyatoa/core/inspector.py
+++ b/pyatoa/core/inspector.py
@@ -918,17 +918,6 @@ class Inspector(InspectorPlotter):
         self.sources = pd.DataFrame()
         self.receivers = pd.DataFrame()
 
-    def report(self, path_out="./insp_report"):
-        """
-        Convenince function that generates a "report" of misfit information for
-        a given inversion. Creates and fills a directory composed of misfit
-        figures and a text file describing important misfit information that a
-        researcher/analyst can quickly browse through to get an idea of
-        inversion health.
-        """
-        if not os.path.exists(path_out):
-            os.mkdir(path_out)
-
     def isolate(self, iteration=None, step_count=None,  event=None,
                 network=None, station=None, channel=None, component=None,
                 keys=None, exclude=None, unique_key=None):

--- a/pyatoa/core/inspector.py
+++ b/pyatoa/core/inspector.py
@@ -70,7 +70,8 @@ class Inspector(InspectorPlotter):
             str_out = (f"{len(self.events):<4} event(s)\n"
                        f"{len(self.stations):<4} station(s)\n"
                        f"{len(self.iterations):<4} iteration(s)\n"
-                       f"{self.evaluations:<4} evaluation(s)")
+                       f"{self.evaluations:<4} evaluation(s)"
+                       )
 
         except KeyError:
             str_out = (f"{0:<4} event(s)\n"
@@ -241,7 +242,7 @@ class Inspector(InspectorPlotter):
         """Return a dictionary of event depths in units of meters"""
         return self._try_print("depth_km")
 
-    def generate_report(self, path_report="./report", iteration=None,
+    def generate_report(self, path_report=None, iteration=None,
                         step_count=None, geographic=True, outliers=True,
                         scatter=True, summary=True, nstd=2,
                         dpi=200, **kwargs):
@@ -280,27 +281,35 @@ class Inspector(InspectorPlotter):
         :type kwargs: dict
         :param kwargs: Additional keyword arguments.
         """
-        if not os.path.exists(path_report):
+        # By default we generate a report for the final model 
+        iteration, step_count = self.validate_evaluation(iteration, step_count,
+                                                         choice="final")
+        if path_report is None:
+            path_report = f"./report_{iteration}{step_count}"
+        if os.path.exists(path_report):
             os.makedirs(path_report)
+
+        kwargs.update(dict(show=False, dpi=dpi))
 
         # Generate some geographic information
         if geographic:
             geographic_plot_functions = ["map", "travel_times", "raypaths",
-                                         "event_depths",]
+                                         "event_depths"]
             for plot_function in geographic_plot_functions:
                 save = os.path.join(path_report, f"{plot_function}.png")
                 if os.path.exists(save):
                     continue
                 getattr(self, plot_function)(iteration=iteration,
-                                             step_count=step_count, show=False,
-                                             save=save, dpi=dpi
-                                             )
+                                             step_count=step_count,
+                                             **kwargs)
+                plt.close()
 
         # Plot misfit spider plots of event misfit for events that are outside
         # N standard deviations of the mean w.r.t misfit value
         if outliers:
             upper_outliers, lower_outliers, mean ,std = \
                 self.event_outliers(iteration, step_count, nstd=nstd)
+            
             if upper_outliers.empty and lower_outliers.empty:
                 logger.warning("No outliers found, skipping outlier plots, " 
                                "reduce `nstd` to reevaluate for outliers")
@@ -310,10 +319,10 @@ class Inspector(InspectorPlotter):
                     for event_name in outliers.index.to_list():
                         self.event_station_misfit_map(
                             event=event_name, iteration=iteration,
-                            step_count=step_count, show=False,
+                            step_count=step_count, 
                             save=os.path.join(path_report,
                                             f"{tag}_{event_name}.png"),
-                            dpi=dpi
+                            **kwargs
                         )
                         plt.close()
 
@@ -329,8 +338,12 @@ class Inspector(InspectorPlotter):
                              save=os.path.join(path_report, f"{x}_v_{y}.png"),
                              **kwargs)
 
-        # Plot summary that try to show all source receivers together
+        # Plot summary figures that show the status of inversion holistically
         if summary:
+            self.convergence(normalize=True, 
+                             save=os.path.join(path_report, "convergence.png"),
+                             **kwargs)
+
             summary_functions = ["event_station_hist2d", "event_comparison",
                                  "window_stack", "histogram_summary"]
             for plot_function in summary_functions:
@@ -342,44 +355,139 @@ class Inspector(InspectorPlotter):
                     getattr(self, plot_function)(
                         iteration="i01", step_count="s00", 
                         iteration_comp=iteration, step_count_comp=step_count,
-                        show=False, save=save, dpi=dpi
+                        save=save, **kwargs
                         )
                 else:
                     getattr(self, plot_function)(
-                        iteration=iteration, step_count=step_count, show=False,
-                        save=save, dpi=dpi
+                        iteration=iteration, step_count=step_count, save=save, 
+                        **kwargs
                         )
+                plt.close()
+
         plt.close("all")
 
-        self.generate_text_report(iteration, step_count, nstd, path_report)
+        self.generate_report_text(path_report, nstd)
             
-    def generate_text_report(self, iteration=None, step_count=None, nstd=2, 
-                             path_report="./", ):
+    def generate_report_text(self, path_report="./", nstd=1):
         """
         Generate a text report highlighting good/bad performing events and 
         stations that will provide the User a quickly accessible summary of 
         their inversion and may motivate looking at some waveforms
-        """            
+        """       
+        line_break = "\n" + "=" * 80 +"\n"     
+        iter_end, step_end = self.validate_evaluation(
+            iteration=None, step_count=None, choice="final"
+            )
+        
+        # Get an ascended list of misfit/windows per event
+        _windows = self.windows  
+        self.windows = self.isolate(iteration=iter_end, step_count=step_end)
 
-        upper_outliers, lower_outliers, mean ,std = \
-                self.event_outliers(iteration, step_count, nstd=nstd)
+        # Event specific window information
+        win_per_event = self.nwin(level="event")
+        avg_win_per_event = win_per_event.nwin.mean()
+
+        _tenwin = win_per_event.iloc[0].nwin
+        top_event_by_win = win_per_event.iloc[0].name[-1]
+
+        _benwin = win_per_event.iloc[-1].nwin
+        bot_event_by_win = win_per_event.iloc[-1].name[-1]
+
+        win_per_event_str = win_per_event.to_string()
+        
+        # Station specific window information
+        win_per_station = self.nwin(level="station")
+        avg_win_per_station = win_per_station.nwin.mean()
+
+        _tsnwin = win_per_station.iloc[0].nwin
+        top_sta_by_win = win_per_station.iloc[0].name[-1]
+
+        _bsnwin = win_per_station.iloc[-1].nwin
+        bot_sta_by_win = win_per_station.iloc[-1].name[-1]
+
+        win_per_station_str = win_per_station.to_string()
+
+        # Event specific misfit information
+        misfit_per_event = self.misfit(level="event")
+
+        _temsft = misfit_per_event.iloc[0].misfit
+        highest_misfit_event = misfit_per_event.iloc[0].name[-1]
+        
+        _bemsft = misfit_per_event.iloc[-1].misfit
+        lowest_misfit_event = misfit_per_event.iloc[-1].name[-1]
+
+        misfit_per_event_str = misfit_per_event.sort_values(
+            "misfit", ascending=False).to_string()
+        
+        # Station specific misfit information
+        misfit_per_sta = self.misfit(level="station")
+
+        _tsmsft = misfit_per_sta.iloc[0].misfit
+        highest_misfit_sta = misfit_per_sta.iloc[0].name[-1]
+        
+        _bsmsft = misfit_per_sta.iloc[-1].misfit
+        lowest_misfit_sta = misfit_per_sta.iloc[-1].name[-1]
+
+        misfit_per_sta_str = misfit_per_sta.sort_values(
+            "misfit", ascending=False).to_string()
+        
+        # Get windows per component for the current evaluation
+        _windows_eval = self.windows
+        win_str = ""
+        for component in self.windows.component.unique():
+            self.windows = self.isolate(component=component)
+            # Sort of a hacky way of getting what we know is a single value
+            nwin_per_comp = self.nwin().nwin.to_list()[0]
+            win_str += f"- {component}: {nwin_per_comp}\n"
+            self.windows = _windows_eval
+
+        self.windows = _windows  # restore to previous state
+
+        srcrcv_summary = (
+            f"Avg windows per event:  {avg_win_per_event:.2f}\n"
+            f"- Evt w/ max win:       {top_event_by_win} ({_tenwin:.0f})\n"
+            f"- Evt w/ min win:       {bot_event_by_win} ({_benwin:.0f})\n"
+            f"- Evt w/ max msft:      {highest_misfit_event} ({_temsft:.2f})\n"
+            f"- Evt w/ min msft:      {lowest_misfit_event} ({_bemsft:.2f})\n"
+            "\n"
+            f"Avg windows per sta:    {avg_win_per_station:.2f}\n"
+            f"- Sta w/ max win:       {top_sta_by_win} ({_tsnwin:.0f})\n"
+            f"- Sta w/ min win:       {bot_sta_by_win} ({_bsnwin:.0f})\n"
+            f"- Sta w/ max msft:      {highest_misfit_sta} ({_tsmsft:.2f})\n"
+            f"- Sta w/ min msft:      {lowest_misfit_sta}  ({_bsmsft:.2f})\n"
+            "\n"
+            f"Windows per component:\n"
+            f"{win_str}"
+            )
+
+        # Get event mean and std for current evaluation
+        _, _, mean ,std = \
+                self.event_outliers(iter_end, step_end, nstd=nstd)
+
+        # Header contains general information for understanding inversion
+        report = [
+            f"{'INSPECTOR REPORT':^80}",
+            f"{'SUMMARY':^80}",
+            f"{self._get_str()}", 
+            f"{f'SRCRCV SUMMARY [{iter_end}{step_end}]':^80}",
+            f"{srcrcv_summary}",
+            f"{'TOTAL WINDOWS':^80}",
+            f"{self.nwin().to_string()}",  
+            f"{'TOTAL MISFIT':^80}",
+            f"{self.misfit().to_string()}", 
+            f"{'WINDOWS PER EVENT':^80}",
+            f"{win_per_event_str}",  
+            f"{f'MISFIT PER EVENT (MEAN={mean:.2f}, {nstd}STD={std:.2f})':^80}",
+            f"{misfit_per_event_str}", 
+            f"{'WINDOWS PER STATION':^80}",
+            f"{win_per_station_str}",
+            f"{f'MISFIT PER STATION':^80}",
+            f"{misfit_per_sta_str}", 
+        ]
         
         # Generate a text report of poorly performing events and stations
         with open(os.path.join(path_report, "inspector_report.txt"), "w") as f:
-            f.write("Inspector Report\n\n")
-            f.write("Event Outliers\n")
-            f.write("---------------\n")
-            f.write(f"{'Event':<15}{'Misfit':<15}{'Std':<15}\n")
-            for event_name in upper_outliers.index.to_list():
-                f.write(f"{event_name:<15}{upper_outliers[event_name]:<15}"
-                        f"{std:<15}\n")
-            f.write("\n")
-            f.write("Station Outliers\n")
-            f.write("----------------\n")
-            f.write(f"{'Station':<15}{'Misfit':<15}{'Std':<15}\n")
-            for station_name in upper_outliers.index.to_list():
-                f.write(f"{station_name:<15}{upper_outliers[station_name]:<15}"
-                        f"{std:<15}\n")
+            f.writelines(f"{line_break}".join(report))
 
     def _get_srcrcv_from_dataset(self, ds):
         """
@@ -1436,6 +1544,7 @@ class Inspector(InspectorPlotter):
 
 
 if __name__ == "__main__":
+
     """
     Here we define a simple command-line tool for using the Inspector. Useful 
     for Users who have already generated the inspector, and want to quickly 

--- a/pyatoa/tests/test_inspector.py
+++ b/pyatoa/tests/test_inspector.py
@@ -161,35 +161,12 @@ def test_minmax(seisflows_inspector):
     assert(minmax["dlnA_max"] == pytest.approx(1.03947, .00001))
 
 
-def test_compare(seisflows_inspector):
+def test_compare_events(seisflows_inspector):
     """
     Test inter-event comparisons
     """
     insp = seisflows_inspector.copy()
-    assert(insp.compare().diff_nwin["2013p617227"] == -110)
-
-
-def test_compare_no_data():
-    """
-    Test that compare with no data returns NoneType
-    """
-    insp = Inspector()
-    assert(insp.compare() is None)
-
-
-def test_compare_windows(seisflows_inspector):
-    """
-    TODO Need fixed window inversion results to make this work
-    """
-    pass
-
-
-def test_no_step_information(seisflows_inspector):
-    """
-    TODO Test that when no step information is provided (only iteration),
-    TODO inspector can still handle data
-    """
-    pass
+    assert(insp.compare_events().diff_nwin["2013p617227"] == -110)
 
 
 def test_get_models(seisflows_inspector):

--- a/pyatoa/utils/process.py
+++ b/pyatoa/utils/process.py
@@ -166,8 +166,8 @@ def trim_streams(st_a, st_b, precision=1E-3, force=None):
     :return: trimmed stream objects in the same order as input
     """
     # Check if the times are already the same
-    if st_a[0].stats.starttime - st_b[0].stats.starttime < precision and \
-            st_a[0].stats.endtime - st_b[0].stats.endtime < precision:
+    if abs(st_a[0].stats.starttime - st_b[0].stats.starttime) < precision and \
+            abs(st_a[0].stats.endtime - st_b[0].stats.endtime) < precision:
         logger.debug(f"start and endtimes already match to {precision}")
         return st_a, st_b
 

--- a/pyatoa/utils/process.py
+++ b/pyatoa/utils/process.py
@@ -162,15 +162,6 @@ def trim_streams(st_a, st_b, force=None):
     :return: trimmed stream objects in the same order as input
     :raises AssertionError: if the streams cannot be trimmed successfully
     """
-<<<<<<< HEAD
-    # Check if the times are already the same
-    if abs(st_a[0].stats.starttime - st_b[0].stats.starttime) < precision and \
-            abs(st_a[0].stats.endtime - st_b[0].stats.endtime) < precision:
-        logger.debug(f"start and endtimes already match to {precision}")
-        return st_a, st_b
-
-=======
->>>>>>> devel
     # Force the trim to the start and end times of one of the streams
     if force:
         if force.lower() == "a":

--- a/pyatoa/visuals/insp_plot.py
+++ b/pyatoa/visuals/insp_plot.py
@@ -207,8 +207,8 @@ class InspectorPlotter:
 
         # Ensure we have distance and backazimuth values in the dataframe
         df = self.isolate(iteration=iteration, step_count=step_count,
-                          network=network, station=station, channel=channel,
-                          component=component)
+                          event=event, network=network, station=station, 
+                          channel=channel, component=component)
         df = df.merge(self.srcrcv, on=["event", "network", "station"])
 
         assert(x in df.keys()), f"X value {x} does not match keys {df.keys()}"
@@ -217,7 +217,7 @@ class InspectorPlotter:
         f, ax = plt.subplots(figsize=figsize, dpi=dpi)
         plt.scatter(df[x].to_numpy(), df[y].to_numpy(), zorder=11,
                     marker=marker, c=c, s=s, edgecolors=edgecolors,
-                    linewidths=linewidths, **kwargs)
+                    linewidths=linewidths)
         plt.xlabel(x)
         plt.ylabel(y)
         plt.title(f"{x} vs. {y}; N={len(df[x].to_numpy())}")

--- a/pyatoa/visuals/insp_plot.py
+++ b/pyatoa/visuals/insp_plot.py
@@ -913,7 +913,7 @@ class InspectorPlotter:
         :param choice: choice of misfit value, either 'misfit' or 'nwin' or
             'unscaled_misfit'
         """
-        figsize = kwargs.get("figsize", (8, 8))
+        figsize = kwargs.get("figsize", (8, 4))
         dpi = kwargs.get("dpi", DEFAULT_DPI)
         cmap = kwargs.get("cmap", "plasma")
         iteration, step_count = self.validate_evaluation(iteration, step_count)
@@ -942,11 +942,15 @@ class InspectorPlotter:
         plt.text(x=0, y=mean, s=f"mean={mean:.2f}", fontsize=12, zorder=96)
         for sign in [1, -1]:
             plt.axhline(mean + sign * std, c="k", ls='--', lw=1.75, zorder=95)
+        plt.text(x=0, y=mean + std, s=f"std={std:.2f}", fontsize=12, zorder=96)
+
         # Plot accoutrements
-        plt.xlim([-2, len(arr)+2])
+        plt.xticks(np.arange(0, len(arr), 1))
+        plt.xlim([-0.5, len(arr)-0.5])
         plt.xlabel("Event Index")
         plt.ylabel(choice)
-        plt.title(f"Event Comparison {iteration}{step_count} N={len(arr)}")
+        plt.title(f"Event Comparison {iteration}{step_count} "
+                  f"(N_events={len(arr)})")
         plt.grid(which="both", axis="both")
         default_axes(ax, cbar=cbar, **kwargs)
 

--- a/pyatoa/visuals/insp_plot.py
+++ b/pyatoa/visuals/insp_plot.py
@@ -986,9 +986,9 @@ class InspectorPlotter:
         """
         figsize = kwargs.get("figsize", (16, 10))
         dpi = kwargs.get("dpi", DEFAULT_DPI)
-        cmap = kwargs.get("cmap", "Blues")
+        cmap = kwargs.get("cmap", "viridis")
         nstd = kwargs.get("nstd", 3)
-        vmax_color = kwargs.get("vmax_color", "lime")
+        vmax_color = kwargs.get("vmax_color", "red")
         zero_color = kwargs.get("zero_color", "gray")
         iteration, step_count = self.validate_evaluation(iteration, step_count)
 
@@ -1036,7 +1036,7 @@ class InspectorPlotter:
         cmap.set_over(vmax_color)
 
         ims = plt.imshow(data, cmap=cmap, vmin=0, vmax=vmax)
-        cbar = plt.colorbar(label=choice, shrink=0.75, pad=0.025,
+        cbar = plt.colorbar(label=choice, shrink=0.25, pad=0.025,
                             extend="both")
 
         # Grid out every data point

--- a/pyatoa/visuals/insp_plot.py
+++ b/pyatoa/visuals/insp_plot.py
@@ -1062,8 +1062,8 @@ class InspectorPlotter:
         if show:
             plt.show()
 
-    def hist(self, iteration=None, step_count=None, compare=True,
-             iteration_comp=None, step_count_comp=None, f=None, ax=None,
+    def hist(self, iteration=None, step_count=None, iteration_comp=None, 
+             step_count_comp=None, compare=True, f=None, ax=None,
              event=None, station=None, choice="cc_shift_in_seconds",
              binsize=None, show=True, save=None, **kwargs):
         """
@@ -1147,7 +1147,7 @@ class InspectorPlotter:
                            "relative_endtime": 50,
                            "length_s": 50,
                            "max_cc_value": 0.1,
-                           "nwin": 10,
+                           "nwin": 50,
                            "nwin_sta": 10,
                            }[choice]
             except KeyError:
@@ -1305,7 +1305,7 @@ class InspectorPlotter:
 
         return f, ax
 
-    def histogram_summary(self, iteration=None, step_count=None, compare=False,
+    def histogram_summary(self, iteration=None, step_count=None,
                           iteration_comp=None, step_count_comp=None,
                           show=True, save=False, **kwargs):
         """
@@ -1315,7 +1315,6 @@ class InspectorPlotter:
         """
         figsize = kwargs.get("figsize", (8, 8))
         dpi = kwargs.get("dpi", DEFAULT_DPI)
-
 
         choices = [
             ["cc_shift_in_seconds", "dlnA", "max_cc_value"],
@@ -1332,12 +1331,14 @@ class InspectorPlotter:
             for col in range(0, ncols):
                 ax = plt.subplot(gs[row, col])
                 self.hist(choice=choices[row][col], iteration=iteration,
-                          step_count=step_count, compare=compare,
-                          iteration_comp=iteration_comp,
+                          step_count=step_count, iteration_comp=iteration_comp, 
+                          compare=True,
                           step_count_comp=step_count_comp, f=f, ax=ax,
                           show=False, figsize=(figsize[0] / nrows,
                                                figsize[1] / ncols),
-                          fontsize=10, title_fontsize=10, **kwargs
+                          fontsize=8, title_fontsize=8, label_fontsize=8, 
+                          tick_fontsize=8,
+                          **kwargs
                           )
 
         if save:


### PR DESCRIPTION
<!--
Thank your for contributing to Pyatoa.
Please fill out the following before submitting your PR.
-->

### What does this PR do?
Improves the `Inspector.generate_report()` function which automatically generates figures that might be useful for understanding/assessing a SeisFlows inversion.

#### Changelog
- New `generate_report_text` function which provides a text report on windows, misfit, and per-event/per-station stats
- Function `Inspector.compare` now named `Inspector.compare_events` to be more descriptive
- New function `compare_misfits` to compare misfit values for two models for each source-receiver pair
- New plotting function `events_over_inversion` to look at the misfit of each event over the course of an inversion
- Rearrange default position of input arguments for `Inspector.hist` and `Inspector_histogram_summary` so that the new call structure is more intuitive

### Why was it initiated?  Any relevant Issues?
Inspector report was underdeveloped and not super useful in previous versions, this makes some changes so that User can just call `Inspector.generate_report()` and not have to sift through all the individual functions/plotting routines to figure out what they might need.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [ ] Any new features or fixed regressions covered by new tests.
- [ ] Any new or changed features have been fully documented.
- [ ] Significant changes have been added to `CHANGELOG.md`.
- [ ] First time contributors have added your name to CONTRIBUTORS.txt .


