### PR TITLE
Bugfi: measure with no windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.4.1
+
+- Bugfix: no window selection did not allow measure to be called due to some
+  incorrect referencing
+
 ## v0.3.0
 
 >__Note__: The motivation behind the changes in v0.3.0 were that the original 

--- a/pyatoa/core/manager.py
+++ b/pyatoa/core/manager.py
@@ -1239,7 +1239,8 @@ class Manager:
         else:
             logger.debug("no windows given, adjoint sources will be "
                          "calculated on full trace")
-            for comp in self.config.component_list:
+            component_list = list(set(_.stats.component for _ in self.st_syn))
+            for comp in component_list:
                 dt = self.st_obs.select(component=comp)[0].stats.delta
                 npts = self.st_obs.select(component=comp)[0].stats.npts
                 # We offset the bounds of the entire trace by 1s to play nice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyatoa"
-version = "0.4.0"
+version = "0.4.1"
 description = "Python's Adjoint Tomography Operations Assistant"
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
When User did not use the Manager.window() function, with the intent of generating adjoint sources for the entire trace, running `Manager.measure()` led to an error due to some incorrect calls. Fixed that.